### PR TITLE
Fix minor texinfo markup error

### DIFF
--- a/inst/pkj.m
+++ b/inst/pkj.m
@@ -154,7 +154,7 @@
 ##
 ## @example
 ## pkj load image
-## pkj load image@2.8.1
+## pkj load image@@2.8.1
 ## @end example
 ##
 ## @noindent


### PR DESCRIPTION
Just a small texinfo markup typo that I noticed when installing the package for the first time.